### PR TITLE
VirtualMachineService and VirtualMachineResourcePolicy can be namespaced

### DIFF
--- a/api/v1alpha1/virtualmachineservice_types.go
+++ b/api/v1alpha1/virtualmachineservice_types.go
@@ -99,7 +99,6 @@ type VirtualMachineServiceStatus struct {
 }
 
 // +genclient
-// +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName=vmservice
 // +kubebuilder:storageversion

--- a/api/v1alpha1/virtualmachinesetresourcepolicy_types.go
+++ b/api/v1alpha1/virtualmachinesetresourcepolicy_types.go
@@ -54,7 +54,6 @@ type ClusterModuleStatus struct {
 }
 
 // +genclient
-// +genclient:nonNamespaced
 // +kubebuilder:object:root=true
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status


### PR DESCRIPTION
This seems to have been a typo in the annotations on the APIs resulting in the wrong signatures being generated in the generated client.