### PR TITLE
Introduce OvfEnv VmMetadataTransport

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -64,7 +64,7 @@ const (
 	VirtualMachineMetadataExtraConfigTransport VirtualMachineMetadataTransport = "ExtraConfig"
 
 	// VirtualMachineMetadataOvfEnvTransport will set the VirtualMachineMetadata ConfigMap data as
-	// vApp properties on the VM, which will be exposed as OvfEnv to the VM Guest. Only properties
+	// vApp properties on the VM, which will be exposed as OvfEnv to the Guest VM. Only properties
 	// marked userConfigurable and already present in either OVF Properties of a VirtualMachineImage
 	// or as vApp properties on an existing VM or VMTX will be set, all others will be ignored.
 	VirtualMachineMetadataOvfEnvTransport VirtualMachineMetadataTransport = "OvfEnv"

--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -55,6 +55,21 @@ type VirtualMachineNetworkInterface struct {
 	EthernetCardType string `json:"ethernetCardType,omitempty"`
 }
 
+// VirtualMachineMetadataTransport is used to indicate the transport used by VirtualMachineMetadata
+type VirtualMachineMetadataTransport string
+
+const (
+	// VirtualMachineMetadataExtraConfigTransport will set the VirtualMachineMetadata ConfigMap data as
+	// extraConfig key value fields on the VM.
+	VirtualMachineMetadataExtraConfigTransport VirtualMachineMetadataTransport = "ExtraConfig"
+
+	// VirtualMachineMetadataOvfEnvTransport will set the VirtualMachineMetadata ConfigMap data as
+	// vApp properties on the VM, which will be exposed as OvfEnv to the VM Guest. Only properties
+	// marked userConfigurable and already present in either OVF Properties of a VirtualMachineImage
+	// or as vApp properties on an existing VM or VMTX will be set, all others will be ignored.
+	VirtualMachineMetadataOvfEnvTransport VirtualMachineMetadataTransport = "OvfEnv"
+)
+
 // VirtualMachineMetadata defines any metadata that should be passed to the VirtualMachine instance.  A typical use
 // case is for this metadata to be used for Guest Customization, however the intended use of the metadata is
 // agnostic to the VirtualMachine controller.  VirtualMachineMetadata is read from a configured ConfigMap and then
@@ -66,9 +81,8 @@ type VirtualMachineMetadata struct {
 	ConfigMapName string `json:"configMapName,omitempty"`
 
 	// Transport describes the name of a supported VirtualMachineMetadata transport "protocol".  Currently, the only supported
-	// transport prototocol is "ExtraConfig".  The ExtraConfig protocol places the VM Metadata as "ExtraConfig" on the
-	// vSphere VM ConfigSpec when creating the VirtualMachine.
-	Transport string `json:"transport,omitempty"`
+	// transport prototocos are "ExtraConfig" and "OvfEnv".
+	Transport VirtualMachineMetadataTransport `json:"transport,omitempty"`
 }
 
 // VirtualMachineVolume describes a Volume that should be attached to a specific VirtualMachine.  Currently,


### PR DESCRIPTION
OvfEnv is a standard way to transport key/value vm customization data from the infrastructure to the VM, as well as exposing them to guest os/apps within the VM. Possible key/value properties that are userConfigurable would be already defined in the .ovf image as defined in the OVF Spec 2.1.1 Section 11 https://www.dmtf.org/sites/default/files/standards/documents/DSP0243_2.1.1.pdf 

This MR makes it possible to supply key/value fields to set the userConfigurable property fields on a .ovf during the VirtualMachine create time. The VirtualMachine spec already has a VmMetadata field which already supports a "ExtraConfig" transport, and this change adds another possible transport which is "OvfEnv". 