### PR TITLE
Include additional VM status phases

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -21,12 +21,22 @@ const (
 type VMStatusPhase string
 
 const (
+	// The Creating phase indicates that the VirtualMachine is being created by the backing infrastructure provider.
+	Creating VMStatusPhase = "Creating"
+
 	// The Created phase indicates that the VirtualMachine has been already been created by the backing infrastructure
 	// provider.
 	Created VMStatusPhase = "Created"
 
+	// The Deleting phase indicates that the VirtualMachine is being deleted by the backing infrastructure provider.
+	Deleting VMStatusPhase = "Deleting"
+
 	// The Deleted phase indicates that the VirtualMachine has been deleted by the backing infrastructure provider.
 	Deleted VMStatusPhase = "Deleted"
+
+	// The Unknown phase indicates that the VirtualMachine status cannot be determined from the backing infrastructure
+	// provider.
+	Unknown VMStatusPhase = "Unknown"
 )
 
 // VirtualMachinePort is unused and can be considered deprecated.


### PR DESCRIPTION
We currently only have 'Created' and 'Deleted' as possible VM status phases. As a result, we don't have a means to represent any intermediate phases that the VM goes through. It would be useful to have the following additional phases:

Creating
Deleting
Unknown
It would certainly help give feedback to the user/client that the system is processing the input (Create/Delete). Also, 'Unknown' would help the client identify situations when VM Operator cannot determine the current state of the VM through its provider.