### PR TITLE
Add SupportedOS boolean flag to the VirtualMachineImage status 

### DIFF
--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -64,9 +64,10 @@ type VirtualMachineImageSpec struct {
 
 // VirtualMachineImageStatus defines the observed state of VirtualMachineImage
 type VirtualMachineImageStatus struct {
-	Uuid       string `json:"uuid,omitempty"`
-	InternalId string `json:"internalId"`
-	PowerState string `json:"powerState,omitempty"`
+	Uuid        string `json:"uuid,omitempty"`
+	InternalId  string `json:"internalId"`
+	PowerState  string `json:"powerState,omitempty"`
+	SupportedOS bool   `json:"supportedOS,omitempty"`
 }
 
 // +genclient
@@ -77,6 +78,7 @@ type VirtualMachineImageStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"
 // +kubebuilder:printcolumn:name="OsType",type="string",JSONPath=".spec.osInfo.type"
+// +kubebuilder:printcolumn:name="SupportedOS",type="bool",JSONPath=".status.supportedOS"
 
 // VirtualMachineImage is the Schema for the virtualmachineimages API
 // A VirtualMachineImage represents a VirtualMachine image (e.g. VM template) that can be used as the base image


### PR DESCRIPTION
InvalidGuestOSType is used to indicate that the GuestOS Type in VirtualMachineImageOSInfo is Invalid
and helps with validation during  VirtualMachineImage creation