### PR TITLE
Improve VM Image column UX

### DIFF
--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -81,6 +81,8 @@ type VirtualMachineImageStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"
 // +kubebuilder:printcolumn:name="OsType",type="string",JSONPath=".spec.osInfo.type"
+// +kubebuilder:printcolumn:name="Format",type="string",JSONPath=".spec.type"
+// +kubebuilder:printcolumn:name="Source",type="string",JSONPath=".spec.imageSourceType"
 // +kubebuilder:printcolumn:name="GOSC_Supported",type="boolean",priority=1,JSONPath=".status.goscSupported"
 
 // VirtualMachineImage is the Schema for the virtualmachineimages API


### PR DESCRIPTION
This change adds two additional columns for `kubectl get virtualmachineimages`: Format and Source.
|Colums|Source|Description|
|-------|--------|-----------|
|`Format`|`.spec.type`|Describes template's type: ovf or vmtx|
|`Source`|`.spec.imageSourceType`|Points to content distribution platform - Content Library|

Example output:
```
kubectl get virtualmachineimages
NAME             VERSION    OSTYPE   FORMAT       SOURCE
photon-1568934    1.16      photon    ovf     Content Library
ubuntu-1778966    1.12      ubuntu    vmtx    Content Library
```
