### PR TITLE
Clean up comment

### DIFF
--- a/api/v1alpha1/virtualmachineservice_types.go
+++ b/api/v1alpha1/virtualmachineservice_types.go
@@ -93,7 +93,6 @@ type VirtualMachineServiceSpec struct {
 	// +optional
 	LoadBalancerIP string `json:"loadBalancerIP,omitempty"`
 
-	// Just support cluster IP for now
 	ClusterIP    string `json:"clusterIp,omitempty"`
 	ExternalName string `json:"externalName,omitempty"`
 }


### PR DESCRIPTION
1. Other types, eg: LoadBalancer is also supported besides Client IP