### PR TITLE
Remove 'Source' column from "kubectl get virtualmachineimages"

### DIFF
--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -87,7 +87,6 @@ type VirtualMachineImageStatus struct {
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"
 // +kubebuilder:printcolumn:name="OsType",type="string",JSONPath=".spec.osInfo.type"
 // +kubebuilder:printcolumn:name="Format",type="string",JSONPath=".spec.type"
-// +kubebuilder:printcolumn:name="Source",type="string",JSONPath=".spec.imageSourceType"
 // +kubebuilder:printcolumn:name="GuestOSCustomizable",type="boolean",priority=1,JSONPath=".status.guestOsCustomizable"
 
 // VirtualMachineImage is the Schema for the virtualmachineimages API


### PR DESCRIPTION
Since VM operator only supports one type of Source - 'Content library'
for MVP, we can get rid of the SOURCE column in the default output.
This can be reintroduced later when needed.