### PR TITLE
Add Condition and Reasons for VirtualMachineClassBindings and VirtualMachineClasses

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -9,15 +9,31 @@ const (
 	ReadyCondition ConditionType = "Ready"
 )
 
+// Conditions and condition Reasons for the VirtualMachine object.
+
+const (
+	// VirtualMachinePrereqReadyCondition documents that all of a VirtualMachine's prerequisites declared in the spec
+	// (e.g. VirtualMachineClass) are satisfied.
+	VirtualMachinePrereqReadyCondition ConditionType = "VirtualMachinePrereqReady"
+
+	// VirtualMachineClassBindingNotFoundReason (Severity=Error) documents a missing VirtualMachineClassBinding for the
+	// VirtualMachineClass specified in the VirtualMachineSpec.
+	VirtualMachineClassBindingNotFoundReason = "VirtualMachineClassBindingNotFound"
+
+	// VirtualMachineClassNotFoundReason (Severity=Error) documents that the VirtualMachineClass specified in the VirtualMachineSpec
+	// is not available.
+	VirtualMachineClassNotFoundReason = "VirtualMachineClassNotFound"
+)
+
 // Common Condition.Reason used by VM Operator API objects.
 const (
-	// DeletingReason (Severity=Info) documents an condition not in Status=True because the underlying object it is currently being deleted.
+	// DeletingReason (Severity=Info) documents a condition not in Status=True because the underlying object it is currently being deleted.
 	DeletingReason = "Deleting"
 
-	// DeletionFailedReason (Severity=Warning) documents an condition not in Status=True because the underlying object
+	// DeletionFailedReason (Severity=Warning) documents a condition not in Status=True because the underlying object
 	// encountered problems during deletion. This is a warning because the reconciler will retry deletion.
 	DeletionFailedReason = "DeletionFailed"
 
-	// DeletedReason (Severity=Info) documents an condition not in Status=True because the underlying object was deleted.
+	// DeletedReason (Severity=Info) documents a condition not in Status=True because the underlying object was deleted.
 	DeletedReason = "Deleted"
 )


### PR DESCRIPTION
There are many developer workflows where do not provide any user feedback. This
change defines a Condition and a few reasons to address some of those
workflows.

The following Condition is defined:
- VirtualMachinePreReqReady:
A condition that represents that all the Prerequisites of a `VirtualMachine` are
ready. For now, we only check for the availability of `VirtualMachineClass` and
the that the class is associated with the VirtualMachine's namespace. In future,
this Condition can be used to check for other components as well
(e.g. `VirtualMachineImage`, `StorageClass` etc).

A few reasons are also defined:
- VirtualMachineClassBindingNotFound
If the VirtualMachine's namespace does not have access to the specified
`VirtualMachineClass`.
- VirtualMachineClassNotFound
If the specified `VirtualMachineClass` does not exist on the cluster.