### PR TITLE
Add some useful columns to 'kubectl get'

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -336,6 +336,10 @@ func (vm *VirtualMachine) SetConditions(conditions Conditions) {
 // +kubebuilder:resource:scope=Namespaced,shortName=vm
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.powerState"
+// +kubebuilder:printcolumn:name="Class",type="string",priority=1,JSONPath=".spec.className"
+// +kubebuilder:printcolumn:name="Image",type="string",priority=1,JSONPath=".spec.imageName"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // VirtualMachine is the Schema for the virtualmachines API.
 // A VirtualMachine represents the desired specification and the observed status of a VirtualMachine instance.  A

--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -56,6 +56,9 @@ type VirtualMachineClassStatus struct {
 // +kubebuilder:resource:scope=Cluster,shortName=vmclass
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.hardware.cpus"
+// +kubebuilder:printcolumn:name="Memory",type="string",JSONPath=".spec.hardware.memory"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // VirtualMachineClass is the Schema for the virtualmachineclasses API.
 // A VirtualMachineClass represents the desired specification and the observed status of a VirtualMachineClass

--- a/api/v1alpha1/virtualmachineclassbinding_types.go
+++ b/api/v1alpha1/virtualmachineclassbinding_types.go
@@ -20,6 +20,7 @@ type ClassReference struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=vmclassbinding
 // +kubebuilder:printcolumn:name="VirtualMachineClass",type="string",JSONPath=".classRef.name"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // VirtualMachineClassBinding is a binding object responsible for
 // defining a VirtualMachineClass and a Namespace associated with it

--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -88,6 +88,7 @@ type VirtualMachineImageStatus struct {
 // +kubebuilder:printcolumn:name="OsType",type="string",JSONPath=".spec.osInfo.type"
 // +kubebuilder:printcolumn:name="Format",type="string",JSONPath=".spec.type"
 // +kubebuilder:printcolumn:name="SupportedGuestOS",type="boolean",priority=1,JSONPath=".status.supportedGuestOS"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // VirtualMachineImage is the Schema for the virtualmachineimages API
 // A VirtualMachineImage represents a VirtualMachine image (e.g. VM template) that can be used as the base image

--- a/api/v1alpha1/virtualmachineservice_types.go
+++ b/api/v1alpha1/virtualmachineservice_types.go
@@ -118,6 +118,8 @@ type VirtualMachineServiceStatus struct {
 // +kubebuilder:resource:shortName=vmservice
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".spec.type"
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // VirtualMachineService is the Schema for the virtualmachineservices API.
 // A VirtualMachineService represents the desired specification and the observed status of a VirtualMachineService


### PR DESCRIPTION
- Adding powerState on default and class, image on -o wide for virtualmachine
- Adding serviceType to virtualmachineservice
- Adding cpu & memory to virtualmachineclass
- Adding Age columns to crds with additional columns since they are omitted
from default when columns are mentioned explicitly for a crd.

Testing Done: 
```
root@4212e95af1461a21e76bcd525ad63941 [ ~ ]# kubectl get vm -A
NAMESPACE    NAME                          POWERSTATE   AGE
test-ns   jenkins-workload-1611253951   poweredOn    25h

root@4212e95af1461a21e76bcd525ad63941 [ ~ ]# kubectl get vm -o wide -A
NAMESPACE    NAME                          POWERSTATE   CLASS                IMAGE                       AGE
test-ns   jenkins-workload-1611253951   poweredOn    best-effort-xsmall   bitnami-jenkins-2.222.3-1   25h

root@4212e95af1461a21e76bcd525ad63941 [ ~ ]# kubectl get vmservice -A
NAMESPACE    NAME                          TYPE           AGE
test-ns   jenkins-workload-1611253951   LoadBalancer   26h

root@4212e95af1461a21e76bcd525ad63941 [ ~ ]# kubectl get virtualmachineclasses -A
NAME                  CPU   MEMORY   AGE
best-effort-2xlarge   8     64Gi     8d
best-effort-4xlarge   16    128Gi    8d
best-effort-8xlarge   32    128Gi    8d

root@4212e95af1461a21e76bcd525ad63941 [ ~ ]# kubectl get vmimage -A
NAME                        VERSION   OSTYPE              FORMAT   AGE
bitnami-jenkins-2.222.3-1             otherLinux64Guest   ovf      7d21h

root@4212e95af1461a21e76bcd525ad63941 [ ~ ]# kubectl get vmclassbinding -A
NAMESPACE    NAME                 VIRTUALMACHINECLASS   AGE
test-ns   best-effort-xsmall   best-effort-xsmall    42h

```