### PR TITLE
Add Condition and Reasons for ContentSourceBindings and VM Images

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -23,6 +23,18 @@ const (
 	// VirtualMachineClassNotFoundReason (Severity=Error) documents that the VirtualMachineClass specified in the VirtualMachineSpec
 	// is not available.
 	VirtualMachineClassNotFoundReason = "VirtualMachineClassNotFound"
+
+	// ContentSourceBindingNotFoundReason (Severity=Error) documents a missing ContentSourceBinding for the
+	// VirtualMachineImage specified in the VirtualMachineSpec.
+	ContentSourceBindingNotFoundReason = "ContentSourceBindingNotFound"
+
+	// ContentLibraryProviderNotFoundReason (Severity=Error) documents that the ContentLibraryProvider corresponding to a VirtualMachineImage
+	// is not available.
+	ContentLibraryProviderNotFoundReason = "ContentLibraryProviderNotFound"
+
+	// VirtualMachineImageNotFoundReason (Severity=Error) documents that the VirtualMachineImage specified in the VirtualMachineSpec
+	// is not available.
+	VirtualMachineImageNotFoundReason = "VirtualMachineImageNotFound"
 )
 
 // Common Condition.Reason used by VM Operator API objects.


### PR DESCRIPTION
In order to provide better feedback to users when a VirtualMachineImage
specified in the VirtualMachine yaml is not available on the API server, or, if
the  developer's namespace does not have access to those images, this change
introduces Reasons that can be set on the conditions as part of the
VirtualMachine's Status.

Following Reasons are defined:
- ContentSourceBindingNotFoundReason
If the developer's namespace does not have access to use the specified
VirtualMachineImage.

- VirtualMachineImageNotFoundReason
If the specified VirtualMachineImage is not found.

These reasons are set on the VirtualMachinePreReqReady condition.