### PR TITLE
Update comment on extraConfig transport stating only guestinfo* prefixed keys to be allowed

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -98,7 +98,7 @@ type VirtualMachineMetadataTransport string
 
 const (
 	// VirtualMachineMetadataExtraConfigTransport will set the VirtualMachineMetadata ConfigMap data as
-	// extraConfig key value fields on the VM.
+	// extraConfig key value fields on the VM. Only keys prefixed with "guestinfo." will be set.
 	VirtualMachineMetadataExtraConfigTransport VirtualMachineMetadataTransport = "ExtraConfig"
 
 	// VirtualMachineMetadataOvfEnvTransport will set the VirtualMachineMetadata ConfigMap data as


### PR DESCRIPTION
Update comment on extraConfig transport stating only guestinfo* prefixed keys to be allowed