### PR TITLE
Remove unsupported vSphere disk creation comment

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -147,7 +147,7 @@ type VsphereVolumeSource struct {
 	// +optional
 	Capacity corev1.ResourceList `json:"capacity,omitempty"`
 
-	// Device key of vSphere disk.  Empty deviceKey means it should be created in vSphere.
+	// Device key of vSphere disk.
 	// +optional
 	DeviceKey *int `json:"deviceKey,omitempty"`
 }


### PR DESCRIPTION
This was not implemented: only resize of the existing disks was
implemented. PVC should be used instead to attach new disks.

The use of optional doesn't necessarily make sense in this struct
but leaving it as-is since that would otherwise be a breaking change.