### PR TITLE
Add GPU profile name related information to kubectl get vmclass command

### DIFF
--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -80,6 +80,8 @@ type VirtualMachineClassStatus struct {
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.hardware.cpus"
 // +kubebuilder:printcolumn:name="Memory",type="string",JSONPath=".spec.hardware.memory"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
+// +kubebuilder:printcolumn:name="VGPUDevices",type="string",priority=1,JSONPath=".spec.hardware.devices.vgpuDevices"
+// +kubebuilder:printcolumn:name="PassthroughDevices",type="string",priority=1,JSONPath=".spec.hardware.devices.dynamicDirectPathIODevices"
 
 // VirtualMachineClass is the Schema for the virtualmachineclasses API.
 // A VirtualMachineClass represents the desired specification and the observed status of a VirtualMachineClass


### PR DESCRIPTION
This patch adds GPU and Direct path IO device related information to the
kubectl get vmclass command in `-o wide` mode

If a VMClass does not have VGPU/Passthrough devices added, then the field will show up
as empty in the get output

Testing Completed:
```
root@42255e5e354ccbd32859ca7470f8897f [ ~ ]# kubectl get virtualmachineclasses.vmoperator.vmware.com vmclass-vgpu-mockup-vmiop -o wide
NAME                        CPU   MEMORY   AGE   VGPUDEVICES                        PASSTHROUGHDEVICES
vmclass-vgpu-mockup-vmiop   2     2Gi      32m   [{"profileName":"mockup-vmiop"}]
root@42255e5e354ccbd32859ca7470f8897f [ ~ ]# kubectl get virtualmachineclasses.vmoperator.vmware.com vmclass-vgpu-mockup-vmiopNAME                        CPU   MEMORY   AGE
vmclass-vgpu-mockup-vmiop   2     2Gi      33m

root@42255e5e354ccbd32859ca7470f8897f [ ~ ]# kubectl get virtualmachineclasses.vmoperator.vmware.com
NAME                        CPU   MEMORY   AGE
best-effort-2xlarge         8     64Gi     5h41m
best-effort-4xlarge         16    128Gi    5h41m
best-effort-8xlarge         32    128Gi    5h41m
best-effort-large           4     16Gi     5h41m
best-effort-medium          2     8Gi      5h41m
best-effort-small           2     4Gi      5h41m
best-effort-xlarge          4     32Gi     5h41m
best-effort-xsmall          2     2Gi      5h41m
guaranteed-2xlarge          8     64Gi     5h41m
guaranteed-4xlarge          16    128Gi    5h41m
guaranteed-8xlarge          32    128Gi    5h41m
guaranteed-large            4     16Gi     5h41m
guaranteed-medium           2     8Gi      5h41m
guaranteed-small            2     4Gi      5h41m
guaranteed-xlarge           4     32Gi     5h41m
guaranteed-xsmall           2     2Gi      5h41m
vmclass-vgpu-mockup-vmiop   2     2Gi      33m
root@42255e5e354ccbd32859ca7470f8897f [ ~ ]# kubectl get virtualmachineclasses.vmoperator.vmware.com -o wide
NAME                        CPU   MEMORY   AGE     VGPUDEVICES                        PASSTHROUGHDEVICES
best-effort-2xlarge         8     64Gi     5h42m
best-effort-4xlarge         16    128Gi    5h42m
best-effort-8xlarge         32    128Gi    5h42m
best-effort-large           4     16Gi     5h42m
best-effort-medium          2     8Gi      5h42m
best-effort-small           2     4Gi      5h42m
best-effort-xlarge          4     32Gi     5h42m
best-effort-xsmall          2     2Gi      5h42m
guaranteed-2xlarge          8     64Gi     5h42m
guaranteed-4xlarge          16    128Gi    5h42m
guaranteed-8xlarge          32    128Gi    5h42m
guaranteed-large            4     16Gi     5h42m
guaranteed-medium           2     8Gi      5h42m
guaranteed-small            2     4Gi      5h42m
guaranteed-xlarge           4     32Gi     5h42m
guaranteed-xsmall           2     2Gi      5h42m
vmclass-vgpu-mockup-vmiop   2     2Gi      33m     [{"profileName":"mockup-vmiop"}]
```