### PR TITLE
Add VM Primary IpAddress column to `kubectl get vm -o wide`

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -392,6 +392,7 @@ func (vm *VirtualMachine) SetConditions(conditions Conditions) {
 // +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.powerState"
 // +kubebuilder:printcolumn:name="Class",type="string",priority=1,JSONPath=".spec.className"
 // +kubebuilder:printcolumn:name="Image",type="string",priority=1,JSONPath=".spec.imageName"
+// +kubebuilder:printcolumn:name="Primary-IP",type="string",priority=1,JSONPath=".status.vmIp"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // VirtualMachine is the Schema for the virtualmachines API.


### PR DESCRIPTION
Show vmIP or the "primary" IP address in the
`kubectl get vm -o wide` output.

Testing Done:
```
root@420cddeddb9f4f4df6bee259ad535225 [ ~ ]# kubectl get vm centos-vm-1 -n my-test-namespace -o wide
NAME          POWERSTATE   CLASS                IMAGE                                         PRIMARY-IP          AGE
centos-vm-1   poweredOn    best-effort-medium   centos-stream-8-vmservice-v1alpha1.20210222   192.168.128.5      6d15h
```