### PR TITLE
Change kubectl get vmclass to print unpacked VGPU device and DDPIO devices data

### DIFF
--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -80,8 +80,8 @@ type VirtualMachineClassStatus struct {
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.hardware.cpus"
 // +kubebuilder:printcolumn:name="Memory",type="string",JSONPath=".spec.hardware.memory"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="VGPUDevices",type="string",priority=1,JSONPath=".spec.hardware.devices.vgpuDevices"
-// +kubebuilder:printcolumn:name="PassthroughDevices",type="string",priority=1,JSONPath=".spec.hardware.devices.dynamicDirectPathIODevices"
+// +kubebuilder:printcolumn:name="VGPUDevicesProfileNames",type="string",priority=1,JSONPath=".spec.hardware.devices.vgpuDevices[*].profileName"
+// +kubebuilder:printcolumn:name="PassthroughDeviceIDs",type="string",priority=1,JSONPath=".spec.hardware.devices.dynamicDirectPathIODevices[*].deviceID"
 
 // VirtualMachineClass is the Schema for the virtualmachineclasses API.
 // A VirtualMachineClass represents the desired specification and the observed status of a VirtualMachineClass


### PR DESCRIPTION

We added support to print VGPU device/passthrough device-related information in PR
https://github.com/vmware-tanzu/vm-operator-api/pull/70. 
The PR did not unpack the individual array elements due to this bug, https://github.com/kubernetes/kubectl/issues/517
Since the upstream bug is getting traction, leverage wildcard `*` to unpack profileNames for VGPU devices
and device IDs for passthrough devices in kubectl get vmclass output 

```
root@42255e5e354ccbd32859ca7470f8897f [ ~ ]# kubectl get vmclass -o wide
NAME                            NAME   CPU   MEMORY   AGE     VGPUDEVICESPROFILENAMES   PASSTHROUGHDEVICEIDS
best-effort-2xlarge                    8     64Gi     7d1h
best-effort-4xlarge                    16    128Gi    7d1h
best-effort-8xlarge                    32    128Gi    7d1h
best-effort-large                      4     16Gi     7d1h
best-effort-medium                     2     8Gi      7d1h
best-effort-small                      2     4Gi      7d1h
best-effort-xlarge                     4     32Gi     7d1h
best-effort-xsmall                     2     2Gi      7d1h
guaranteed-2xlarge                     8     64Gi     7d1h
guaranteed-4xlarge                     16    128Gi    7d1h
guaranteed-8xlarge                     32    128Gi    7d1h
guaranteed-large                       4     16Gi     7d1h
guaranteed-medium                      2     8Gi      7d1h
guaranteed-small                       2     4Gi      7d1h
guaranteed-xlarge                      4     32Gi     7d1h
guaranteed-xsmall                      2     2Gi      7d1h
vmclass-passthrough-mockup             2     2Gi      5m35s   mockup-vmiop              23
vmclass-vgpu-mockup-vmiop              2     2Gi      6d19h   mockup-vmiop
vmclass-vgpu-mockup-vmiop-new          2     2Gi      5d1h    mockup-vmiop
root@42255e5e354ccbd32859ca7470f8897f [ ~ ]#
```