### PR TITLE
Add Virtual Hardware Version to the VirtualMachineImage Spec and some cleanup

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -52,6 +52,7 @@ const (
 
 // Conditions related to the VirtualMachineImages
 const(
+	// Deprecated
 	// VirtualMachineImageOSTypeSupportedCondition denotes that the OS type in the VirtualMachineImage object is
 	// supported by VMService. A VirtualMachineImageOsTypeSupportedCondition is marked true:
 	// - If OS Type is of Linux Family
@@ -65,6 +66,7 @@ const(
 
 // Condition.Reason for Conditions related to VirtualMachineImages
 const (
+	// Deprecated
 	// VirtualMachineImageOSTypeNotSupportedReason (Severity=Error) documents that OS Type is VirtualMachineImage is
 	// not supported.
 	VirtualMachineImageOSTypeNotSupportedReason = "VirtualMachineImageOSTypeNotSupported"

--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -78,6 +78,10 @@ type VirtualMachineImageSpec struct {
 	// OVFEnv describes the user configurable customization parameters of the VirtualMachineImage.
 	// +optional
 	OVFEnv map[string]OvfProperty `json:"ovfEnv,omitempty"`
+
+	// HardwareVersion describes the virtual hardware version of the image
+	// +optional
+	HardwareVersion int32 `json:"hwVersion,omitempty"`
 }
 
 // VirtualMachineImageStatus defines the observed state of VirtualMachineImage
@@ -93,7 +97,6 @@ type VirtualMachineImageStatus struct {
 
 	// ImageSupported indicates whether the VirtualMachineImage is supported by VMService.
 	// A VirtualMachineImage is supported by VMService if the following conditions are true:
-	// - VirtualMachineImageOSTypeSupportedCondition
 	// - VirtualMachineImageV1Alpha1CompatibleCondition
 	// +optional
 	ImageSupported *bool `json:"imageSupported,omitempty"`


### PR DESCRIPTION
- This change adds the ovf Hardware Version to the VirtualMachineImage
object.
- It also deprecates some condition constants which won't be used