### PR TITLE
Add Condition Types for VMTools running status

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -57,6 +57,17 @@ const (
 	GuestCustomizationFailedReason = "GuestCustomizationFailed"
 )
 
+const (
+	// VirtualMachineToolsCondition exposes the status of VMware Tools running in the guest OS, when available
+	VirtualMachineToolsCondition ConditionType = "VirtualMachineTools"
+
+	// VirtualMachineToolsNotRunningReason (Severity=Error) documents that VMware Tools is not running
+	VirtualMachineToolsNotRunningReason = "VirtualMachineToolsNotRunning"
+
+	// VirtualMachineToolsRunningReason (Severity=Info) documents that VMware Tools is running
+	VirtualMachineToolsRunningReason = "VirtualMachineToolsRunning"
+)
+
 // Common Condition.Reason used by VM Operator API objects.
 const (
 	// DeletingReason (Severity=Info) documents a condition not in Status=True because the underlying object it is currently being deleted.


### PR DESCRIPTION
This change adds condition types for the running status of
VMware tools, which will be exposed on the VirtualMachine CRD's status