### PR TITLE
Add Cluster to the ClusterModuleStatus

### DIFF
--- a/api/v1alpha1/virtualmachinesetresourcepolicy_types.go
+++ b/api/v1alpha1/virtualmachinesetresourcepolicy_types.go
@@ -49,8 +49,9 @@ type VirtualMachineSetResourcePolicyStatus struct {
 }
 
 type ClusterModuleStatus struct {
-	GroupName  string `json:"groupname"`
-	ModuleUuid string `json:"moduleUUID"`
+	GroupName   string `json:"groupname"`
+	ModuleUuid  string `json:"moduleUUID"`
+	ClusterMoID string `json:"clusterMoID"`
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
This field will contain the domain-XXX that corresponds to the
ClusterComputeResource. The VC Cluster Modules API is not very
friendly for our needs: the module create API does not take a
name or other identifier, so we're force to keep the module ID
in our status to be able to look it up. With future HA support,
we need create the modules on each cluster, so we also need the
cluster in the status.