### PR TITLE
Quick fix to make instanceStorage.volumes omitempty

### DIFF
--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -32,9 +32,9 @@ type InstanceStorage struct {
 	// uses it for configuring instance storage.
 	StorageClass string `json:"storageClass,omitempty"`
 
-	// Volumes describes the number and size of instance storage volumes
-	// created for a VirtualMachine that uses this VirtualMachineClass.
-	Volumes []InstanceStorageVolume `json:"volumes"`
+	// Volumes describes instance storage volumes created for a VirtualMachine
+	// instance that use this VirtualMachineClass.
+	Volumes []InstanceStorageVolume `json:"volumes,omitempty"`
 }
 
 // InstanceStorageVolume contains information required to create an


### PR DESCRIPTION
Otherwise existing classes are invalid:

 ... is invalid: spec.hardware.instanceStorage.volumes: Invalid value: \"null\":
     spec.hardware.instanceStorage.volumes in body must be of type array: \"null\"",

Tweak field wording a bit.

This should use later use CRD validation to enforce a non-empty array.

The optional structs of the VirtualMachineClassHardware probably made/make
more sense as pointers.