### PR TITLE
Remove `VirtualMachineClass` and `ContentSource` from the `kubectl get`

### DIFF
--- a/api/v1alpha1/contentsourcebinding_types.go
+++ b/api/v1alpha1/contentsourcebinding_types.go
@@ -19,7 +19,6 @@ type ContentSourceReference struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced
-// +kubebuilder:printcolumn:name="ContentSource",type="string",JSONPath=".contentSourceRef.name"
 
 // ContentSourceBinding is an object that represents a ContentSource to Namespace mapping.
 type ContentSourceBinding struct {

--- a/api/v1alpha1/virtualmachineclassbinding_types.go
+++ b/api/v1alpha1/virtualmachineclassbinding_types.go
@@ -19,7 +19,6 @@ type ClassReference struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Namespaced,shortName=vmclassbinding
-// +kubebuilder:printcolumn:name="VirtualMachineClass",type="string",JSONPath=".classRef.name"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // VirtualMachineClassBinding is a binding object responsible for


### PR DESCRIPTION
removing VirtualMachineClass column from ```kubectl get virtualmachineclassbindings```
removing ContentSource column from ```kubectl get contentsourcebindings```

```
root@421077164532703f248269ee76533985 [ ~ ]# kubectl get virtualmachineclassbindings -A
NAMESPACE   NAME               AGE
test-ns     guaranteed-small   2m33s
test-ns     test-class         3m
root@421077164532703f248269ee76533985 [ ~ ]# kubectl get contentsourcebindings -A
NAMESPACE           NAME                                   AGE
test-ns             a165e320-4793-4cee-b785-88c0beeaef1b   3m11s
testing-namespace   a165e320-4793-4cee-b785-88c0beeaef1b   46s
```
Co-authored-by: Shijia Hu <hshijia@vmware.com>