### PR TITLE
Add 'Description' field to VM Class CRD

### DIFF
--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -90,6 +90,10 @@ type VirtualMachineClassSpec struct {
 	// policy.  The configuration specified in this field is used to customize various policies related to
 	// infrastructure resource consumption.
 	Policies VirtualMachineClassPolicies `json:"policies,omitempty"`
+
+	// Description describes the configuration of the VirtualMachineClass which is not related to virtual hardware
+	// or infrastructure policy. This field is used to address remaining specs about this VirtualMachineClass.
+	Description VirtualMachineClassDescription `json:"description,omitempty"`
 }
 
 // VirtualMachineClassStatus defines the observed state of VirtualMachineClass.  VirtualMachineClasses are immutable,
@@ -122,7 +126,6 @@ type VirtualMachineClass struct {
 
 	Spec   VirtualMachineClassSpec   `json:"spec,omitempty"`
 	Status VirtualMachineClassStatus `json:"status,omitempty"`
-	Description VirtualMachineClassDescription `json:"description,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -97,6 +97,10 @@ type VirtualMachineClassSpec struct {
 type VirtualMachineClassStatus struct {
 }
 
+// VirtualMachineClassDescription defines the description of VirtualMachineClass.
+type VirtualMachineClassDescription struct {
+}
+
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster,shortName=vmclass
 // +kubebuilder:storageversion
@@ -118,6 +122,7 @@ type VirtualMachineClass struct {
 
 	Spec   VirtualMachineClassSpec   `json:"spec,omitempty"`
 	Status VirtualMachineClassStatus `json:"status,omitempty"`
+	Description VirtualMachineClassDescription `json:"description,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -93,16 +93,12 @@ type VirtualMachineClassSpec struct {
 
 	// Description describes the configuration of the VirtualMachineClass which is not related to virtual hardware
 	// or infrastructure policy. This field is used to address remaining specs about this VirtualMachineClass.
-	Description VirtualMachineClassDescription `json:"description,omitempty"`
+	Description string `json:"description,omitempty"`
 }
 
 // VirtualMachineClassStatus defines the observed state of VirtualMachineClass.  VirtualMachineClasses are immutable,
 // non-dynamic resources, so this status is currently unused.
 type VirtualMachineClassStatus struct {
-}
-
-// VirtualMachineClassDescription defines the description of VirtualMachineClass.
-type VirtualMachineClassDescription struct {
 }
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
For [VMSVC-307](https://jira.eng.vmware.com/browse/VMSVC-307)
VI admins can provide a description of a VM class when they create them from the VC UI (or VAPI). However, that description is not propagated to the custom resource since the CRD doesn't support it. 
To expose description field on -o yaml/-o json, I added a new type VirtualMachineClassDescription and include it in VirtualMachineClass.