### PR TITLE
Set Description field in VM Class to `// +optional`

### DIFF
--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -93,6 +93,7 @@ type VirtualMachineClassSpec struct {
 
 	// Description describes the configuration of the VirtualMachineClass which is not related to virtual hardware
 	// or infrastructure policy. This field is used to address remaining specs about this VirtualMachineClass.
+	// +optional
 	Description string `json:"description,omitempty"`
 }
 


### PR DESCRIPTION
To make sure compatibility in different versions, set description field to optional. So when left empty/not supported, the client would omit marshaling this field.