### PR TITLE
Introduce annotation to pause a VM reconcile

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -43,6 +43,14 @@ const (
 	Unknown VMStatusPhase = "Unknown"
 )
 
+// PauseAnnotation is an annotation that can be applied to any VirtualMachine object to prevent VM Operator from
+// reconciling the object with the vSphere infrastructure.  VM Operator checks the presence of this annotation to
+// skip the reconcile of a VirtualMachine.
+//
+// This can be used when a Virtual Machine needs to be modified out-of-band of VM Operator on the infrastructure
+// directly (e.g., during a VADP based Restore operation).
+const PauseAnnotation = GroupName + "/pause-reconcile"
+
 // VirtualMachinePort is unused and can be considered deprecated.
 type VirtualMachinePort struct {
 	Port     int             `json:"port"`

--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -15,8 +15,8 @@ type VGPUDevice struct {
 
 // DynamicDirectPathIODevice contains the configuration corresponding to a Dynamic DirectPath I/O device.
 type DynamicDirectPathIODevice struct {
-	VendorID    int    `json:"vendorID"`
-	DeviceID    int    `json:"deviceID"`
+	VendorID int `json:"vendorID"`
+	DeviceID int `json:"deviceID"`
 	// +optional
 	CustomLabel string `json:"customLabel,omitempty"`
 }
@@ -46,17 +46,17 @@ type InstanceStorageVolume struct {
 // VirtualDevices contains information about the virtual devices associated with a VirtualMachineClass.
 type VirtualDevices struct {
 	// +optional
-	VGPUDevices                []VGPUDevice                `json:"vgpuDevices,omitempty" patchStrategy:"merge" patchMergeKey:"profileName"`
+	VGPUDevices []VGPUDevice `json:"vgpuDevices,omitempty" patchStrategy:"merge" patchMergeKey:"profileName"`
 	// +optional
 	DynamicDirectPathIODevices []DynamicDirectPathIODevice `json:"dynamicDirectPathIODevices,omitempty"`
 }
 
 // VirtualMachineClassHardware describes a virtual hardware resource specification.
 type VirtualMachineClassHardware struct {
-	Cpus    int64             `json:"cpus,omitempty"`
-	Memory  resource.Quantity `json:"memory,omitempty"`
+	Cpus   int64             `json:"cpus,omitempty"`
+	Memory resource.Quantity `json:"memory,omitempty"`
 	// +optional
-	Devices VirtualDevices    `json:"devices,omitempty"`
+	Devices VirtualDevices `json:"devices,omitempty"`
 	// +optional
 	InstanceStorage InstanceStorage `json:"instanceStorage,omitempty"`
 }


### PR DESCRIPTION
In order to support VADP based backup/restore of VM Service VMs, we
need to pause the reconcile while the VM is recreated from backup on
the infrastructure. This change introduces a pause annotation to
achieve this. When set, VM operator will not reconcile this VM until
this annotation is removed.