### PR TITLE
Add VirtualMachine.Status.Zone

### DIFF
--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -423,6 +423,11 @@ type VirtualMachineStatus struct {
 	// be attached to the VirtualMachine.
 	// +optional
 	NetworkInterfaces []NetworkInterfaceStatus `json:"networkInterfaces,omitempty"`
+
+	// Zone describes the availability zone where the VirtualMachine has been scheduled.
+	// Please note this field may be empty when the cluster is not zone-aware.
+	// +optional
+	Zone string `json:"zone,omitempty"`
 }
 
 func (vm *VirtualMachine) GetConditions() Conditions {


### PR DESCRIPTION
This patch adds .status.zone to the VirtualMachine API in order to surface the zone where a VM has been scheduled in a zone-aware cluster.