### PR TITLE
Make ContentLibraryRef field optional

### DIFF
--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -118,7 +118,8 @@ type VirtualMachineImageStatus struct {
 	Conditions []Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 
 	// ContentLibraryRef is a reference to the source ContentLibrary/ClusterContentLibrary resource.
-	ContentLibraryRef corev1.TypedLocalObjectReference `json:"contentLibraryRef"`
+	// +optional
+	ContentLibraryRef corev1.TypedLocalObjectReference `json:"contentLibraryRef,omitempty"`
 }
 
 func (vmImage *VirtualMachineImage) GetConditions() Conditions {


### PR DESCRIPTION
`ContentLibraryRef` under Status object should not be a require field. Change it to be optional.