### PR TITLE
Update VirtualMachineImage related fields and separate multi-words with dash in print column

### DIFF
--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -93,6 +93,12 @@ const (
 	// VirtualMachineImageV1Alpha1CompatibleCondition denotes image compatibility with VMService. VMService expects
 	// VirtualMachineImage to be prepared by VMware specifically for VMService v1alpha1.
 	VirtualMachineImageV1Alpha1CompatibleCondition ConditionType = "VirtualMachineImageV1Alpha1Compatible"
+
+	// VirtualMachineImageSyncedCondition denotes that the image is synced with the vSphere content library.
+	VirtualMachineImageSyncedCondition ConditionType = "VirtualMachineImageSynced"
+
+	// VirtualMachineImageProviderReadyCondition denotes that the image provider from vSphere is ready.
+	VirtualMachineImageProviderReadyCondition ConditionType = "VirtualMachineImageProviderReady"
 )
 
 // Condition.Reason for Conditions related to VirtualMachineImages.
@@ -105,4 +111,12 @@ const (
 	// VirtualMachineImageV1Alpha1NotCompatibleReason (Severity=Error) documents that the VirtualMachine Image
 	// is not prepared for VMService consumption.
 	VirtualMachineImageV1Alpha1NotCompatibleReason = "VirtualMachineImageV1Alpha1NotCompatible"
+
+	// VirtualMachineImageProviderNotReadyReason (Severity=Error) documents that the VirtualMachine Image provider
+	// from the vSphere content library is not ready.
+	VirtualMachineImageProviderNotReadyReason = "VirtualMachineImageProviderNotReady"
+
+	// VirtualMachineImageNotSynced (Severity=Error) documents that the VirtualMachine Image is not synced with the
+	// latest version from the vSphere content library.
+	VirtualMachineImageNotSyncedReason = "VirtualMachineImageNotSynced"
 )

--- a/api/v1alpha1/condition_consts.go
+++ b/api/v1alpha1/condition_consts.go
@@ -35,6 +35,10 @@ const (
 	// VirtualMachineImageNotFoundReason (Severity=Error) documents that the VirtualMachineImage specified in the VirtualMachineSpec
 	// is not available.
 	VirtualMachineImageNotFoundReason = "VirtualMachineImageNotFound"
+
+	// VirtualMachineImageNotReadyReason (Severity=Error) documents that the VirtualMachineImage specified in the VirtualMachineSpec
+	// is not ready.
+	VirtualMachineImageNotReadyReason = "VirtualMachineImageNotReady"
 )
 
 const (
@@ -94,10 +98,11 @@ const (
 	// VirtualMachineImage to be prepared by VMware specifically for VMService v1alpha1.
 	VirtualMachineImageV1Alpha1CompatibleCondition ConditionType = "VirtualMachineImageV1Alpha1Compatible"
 
-	// VirtualMachineImageSyncedCondition denotes that the image is synced with the vSphere content library.
+	// VirtualMachineImageSyncedCondition denotes that the image is synced with the vSphere content library item
+	// that contains the source of this image's information.
 	VirtualMachineImageSyncedCondition ConditionType = "VirtualMachineImageSynced"
 
-	// VirtualMachineImageProviderReadyCondition denotes that the image provider from vSphere is ready.
+	// VirtualMachineImageProviderReadyCondition denotes readiness of the VirtualMachineImage provider.
 	VirtualMachineImageProviderReadyCondition ConditionType = "VirtualMachineImageProviderReady"
 )
 
@@ -108,15 +113,15 @@ const (
 	// not supported.
 	VirtualMachineImageOSTypeNotSupportedReason = "VirtualMachineImageOSTypeNotSupported"
 
-	// VirtualMachineImageV1Alpha1NotCompatibleReason (Severity=Error) documents that the VirtualMachine Image
+	// VirtualMachineImageV1Alpha1NotCompatibleReason (Severity=Error) documents that the VirtualMachineImage
 	// is not prepared for VMService consumption.
 	VirtualMachineImageV1Alpha1NotCompatibleReason = "VirtualMachineImageV1Alpha1NotCompatible"
 
-	// VirtualMachineImageProviderNotReadyReason (Severity=Error) documents that the VirtualMachine Image provider
-	// from the vSphere content library is not ready.
-	VirtualMachineImageProviderNotReadyReason = "VirtualMachineImageProviderNotReady"
-
-	// VirtualMachineImageNotSynced (Severity=Error) documents that the VirtualMachine Image is not synced with the
-	// latest version from the vSphere content library.
+	// VirtualMachineImageNotSyncedReason (Severity=Error) documents that the VirtualMachineImage is not synced with
+	// the vSphere content library item that contains the source of this image's information.
 	VirtualMachineImageNotSyncedReason = "VirtualMachineImageNotSynced"
+
+	// VirtualMachineImageProviderNotReadyReason (Severity=Error) documents that the VirtualMachineImage provider
+	// is not in ready state.
+	VirtualMachineImageProviderNotReadyReason = "VirtualMachineImageProviderNotReady"
 )

--- a/api/v1alpha1/contentlibraryprovider_types.go
+++ b/api/v1alpha1/contentlibraryprovider_types.go
@@ -21,7 +21,7 @@ type ContentLibraryProviderStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:scope=Cluster
-// +kubebuilder:printcolumn:name="Content Library UUID",type="string",JSONPath=".spec.uuid",description="UUID of the vSphere content library"
+// +kubebuilder:printcolumn:name="Content-Library-UUID",type="string",JSONPath=".spec.uuid",description="UUID of the vSphere content library"
 
 // ContentLibraryProvider is the Schema for the contentlibraryproviders API.
 type ContentLibraryProvider struct {

--- a/api/v1alpha1/virtualmachine_types.go
+++ b/api/v1alpha1/virtualmachine_types.go
@@ -480,7 +480,7 @@ func (vm *VirtualMachine) SetConditions(conditions Conditions) {
 // +kubebuilder:resource:scope=Namespaced,shortName=vm
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="PowerState",type="string",JSONPath=".status.powerState"
+// +kubebuilder:printcolumn:name="Power-State",type="string",JSONPath=".status.powerState"
 // +kubebuilder:printcolumn:name="Class",type="string",priority=1,JSONPath=".spec.className"
 // +kubebuilder:printcolumn:name="Image",type="string",priority=1,JSONPath=".spec.imageName"
 // +kubebuilder:printcolumn:name="Primary-IP",type="string",priority=1,JSONPath=".status.vmIp"

--- a/api/v1alpha1/virtualmachineclass_types.go
+++ b/api/v1alpha1/virtualmachineclass_types.go
@@ -124,8 +124,8 @@ type VirtualMachineClassStatus struct {
 // +kubebuilder:printcolumn:name="CPU",type="string",JSONPath=".spec.hardware.cpus"
 // +kubebuilder:printcolumn:name="Memory",type="string",JSONPath=".spec.hardware.memory"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:printcolumn:name="VGPUDevicesProfileNames",type="string",priority=1,JSONPath=".spec.hardware.devices.vgpuDevices[*].profileName"
-// +kubebuilder:printcolumn:name="PassthroughDeviceIDs",type="string",priority=1,JSONPath=".spec.hardware.devices.dynamicDirectPathIODevices[*].deviceID"
+// +kubebuilder:printcolumn:name="VGPU-Devices-Profile-Names",type="string",priority=1,JSONPath=".spec.hardware.devices.vgpuDevices[*].profileName"
+// +kubebuilder:printcolumn:name="Passthrough-DeviceIDs",type="string",priority=1,JSONPath=".spec.hardware.devices.dynamicDirectPathIODevices[*].deviceID"
 
 // VirtualMachineClass is the Schema for the virtualmachineclasses API.
 // A VirtualMachineClass represents the desired specification and the observed status of a VirtualMachineClass

--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -134,12 +134,13 @@ func (vmImage *VirtualMachineImage) SetConditions(conditions Conditions) {
 // +kubebuilder:resource:scope=Cluster,shortName=vmi;vmimage
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="ContentSourceName",type="string",JSONPath=".spec.providerRef.name"
-// +kubebuilder:printcolumn:name="ContentLibraryName",type="string",JSONPath=".status.contentLibraryRef.name"
+// +kubebuilder:printcolumn:name="Provider-Name",type="string",JSONPath=".spec.providerRef.name"
+// +kubebuilder:printcolumn:name="Content-Library-Name",type="string",JSONPath=".status.contentLibraryRef.name"
+// +kubebuilder:printcolumn:name="Image-Name",type="string",JSONPath=".status.imageName"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"
-// +kubebuilder:printcolumn:name="OsType",type="string",JSONPath=".spec.osInfo.type"
+// +kubebuilder:printcolumn:name="Os-Type",type="string",JSONPath=".spec.osInfo.type"
 // +kubebuilder:printcolumn:name="Format",type="string",JSONPath=".spec.type"
-// +kubebuilder:printcolumn:name="ImageSupported",type="boolean",priority=1,JSONPath=".status.imageSupported"
+// +kubebuilder:printcolumn:name="Image-Supported",type="boolean",priority=1,JSONPath=".status.imageSupported"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // VirtualMachineImage is the Schema for the virtualmachineimages API
@@ -175,12 +176,13 @@ func (clusterVirtualMachineImage *ClusterVirtualMachineImage) SetConditions(cond
 // +kubebuilder:resource:scope=Cluster,shortName=cvmi;cvmimage;clustervmimage
 // +kubebuilder:storageversion
 // +kubebuilder:subresource:status
-// +kubebuilder:printcolumn:name="ContentSourceName",type="string",JSONPath=".spec.providerRef.name"
-// +kubebuilder:printcolumn:name="ContentLibraryName",type="string",JSONPath=".status.contentLibraryRef.name"
+// +kubebuilder:printcolumn:name="Provider-Name",type="string",JSONPath=".spec.providerRef.name"
+// +kubebuilder:printcolumn:name="Content-Library-Name",type="string",JSONPath=".status.contentLibraryRef.name"
+// +kubebuilder:printcolumn:name="Image-Name",type="string",JSONPath=".status.imageName"
 // +kubebuilder:printcolumn:name="Version",type="string",JSONPath=".spec.productInfo.version"
-// +kubebuilder:printcolumn:name="OsType",type="string",JSONPath=".spec.osInfo.type"
+// +kubebuilder:printcolumn:name="Os-Type",type="string",JSONPath=".spec.osInfo.type"
 // +kubebuilder:printcolumn:name="Format",type="string",JSONPath=".spec.type"
-// +kubebuilder:printcolumn:name="ImageSupported",type="boolean",priority=1,JSONPath=".status.imageSupported"
+// +kubebuilder:printcolumn:name="Image-Supported",type="boolean",priority=1,JSONPath=".status.imageSupported"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // ClusterVirtualMachineImage is the schema for the clustervirtualmachineimage API

--- a/api/v1alpha1/virtualmachineimage_types.go
+++ b/api/v1alpha1/virtualmachineimage_types.go
@@ -120,6 +120,11 @@ type VirtualMachineImageStatus struct {
 	// ContentLibraryRef is a reference to the source ContentLibrary/ClusterContentLibrary resource.
 	// +optional
 	ContentLibraryRef *corev1.TypedLocalObjectReference `json:"contentLibraryRef,omitempty"`
+
+	// ContentVersion describes the observed content version of this VirtualMachineImage that was last successfully
+	// synced with the vSphere content library item.
+	// +optional
+	ContentVersion string `json:"contentVersion"`
 }
 
 func (vmImage *VirtualMachineImage) GetConditions() Conditions {

--- a/api/v1alpha1/virtualmachinepublishrequest_types.go
+++ b/api/v1alpha1/virtualmachinepublishrequest_types.go
@@ -195,7 +195,7 @@ type VirtualMachinePublishRequestSpec struct {
 }
 
 // VirtualMachinePublishRequestStatus defines the observed state of a
-//  VirtualMachinePublishRequest.
+// VirtualMachinePublishRequest.
 type VirtualMachinePublishRequestStatus struct {
 	// CompletionTime represents time when the request was completed. It is not
 	// guaranteed to be set in happens-before order across separate operations.


### PR DESCRIPTION
This PR introduces the following changes:
- Add an optional `ContentVersion` field in `VirtualMachineImageStatus`
- Add some constants related to `VirtualMachineImage` conditions
- Update `printcolumn` remarks by adding a dash in multi-word access all types to keep consistency
